### PR TITLE
fix safari input cursor issue

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -135,7 +135,10 @@ export function updateValue(el, { emit = true, force = false } = {}) {
     const newValue = masker(el.value, config)
 
     el[CONFIG_KEY].oldValue = newValue.masked
-    el.value = newValue.masked
+    // fixes safari issue where setting the value also resets cursor to end of input
+    if (el.value !== newValue.masked) {
+      el.value = newValue.masked
+    }
     el.unmaskedValue = newValue.raw
     emit && el.dispatchEvent(FacadeInputEvent())
   }

--- a/tests/directive.test.js
+++ b/tests/directive.test.js
@@ -119,5 +119,17 @@ describe('Directive', () => {
 
       expect(wrapper.element.setSelectionRange).toBeCalledWith(newCursorPos, newCursorPos)
     })
+
+    test('should not reset cursor if no mask is given', async () => {
+      buildWrapper({ mask: '', attachToDocument: true })
+      element = wrapper.element
+      jest.spyOn(element, 'setSelectionRange')
+      element.focus()
+      element.value = 'ABC-1J|2'
+      const cursorPos = element.value.indexOf('|')
+      element.selectionEnd = cursorPos
+      wrapper.find('input').trigger('input', { data: 'J' })
+      expect(wrapper.element.setSelectionRange).not.toBeCalled()
+    })
   })
 })


### PR DESCRIPTION
This PR:
- fixes "cursor jumping to end" issue by preventing value update if no mask is being passed in