### PR TITLE
feat: add 'short' directive modifier

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -21,11 +21,15 @@ export function FacadeInputEvent() {
  * Transform an array or string config into an object
  *
  * @param {object} config The mask config object
+ * @param {object} modifiers An object of modifier flags that can influence the masking process
+ * @param {boolean} modifiers.short to keep the string as short as possible (not append extra chars at the end)
  */
-export function normalizeConfig(config = {}) {
+export function normalizeConfig(config = {}, modifiers = {}) {
   if (Array.isArray(config) || typeof config === 'string') {
     config = { mask: config }
   }
+
+  if (modifiers.short) config.short = true
 
   return config
 }

--- a/src/directive.js
+++ b/src/directive.js
@@ -2,12 +2,12 @@ import * as core from './core'
 const CONFIG_KEY = core.CONFIG_KEY
 
 export default {
-  bind: function(el, binding) {
+  bind: function(el, { value, modifiers }) {
     el = core.getInputElement(el)
     el.addEventListener('input', core.inputHandler, true)
 
     el[CONFIG_KEY] = {
-      config: core.normalizeConfig(binding.value)
+      config: core.normalizeConfig(value, modifiers)
       // TODO: if we set this here it won't try to mask on initial value
       // should this be a default bahaviour?
       // oldValue: el.value
@@ -17,11 +17,11 @@ export default {
     core.updateValue(el)
   },
 
-  update: (el, { value, oldValue }) => {
+  update: (el, { value, oldValue, modifiers }) => {
     el = core.getInputElement(el)
 
     if (value !== oldValue) {
-      el[CONFIG_KEY].config = core.normalizeConfig(value)
+      el[CONFIG_KEY].config = core.normalizeConfig(value, modifiers)
       core.updateValue(el, { force: true })
     } else {
       core.updateValue(el)

--- a/tests/directive.test.js
+++ b/tests/directive.test.js
@@ -67,6 +67,19 @@ describe('Directive', () => {
     expect(wrapper.element.unmaskedValue).toBe('1122')
   })
 
+  test('Should honor short modifier', async () => {
+    buildWrapper({
+      template: `<input v-facade.short="mask" value="12" @input="inputListener" />`
+    })
+    expect(wrapper.element.value).toBe('12')
+
+    wrapper.element.value = '1234'
+    wrapper.find('input').trigger('input')
+
+    expect(wrapper.element.value).toBe('12.34')
+    expect(wrapper.element.unmaskedValue).toBe('1234')
+  })
+
   test('Should not update the cursor position if not the active element', () => {
     buildWrapper({ value: 'ABCDE' })
 


### PR DESCRIPTION
Our use case requires only adding non-masked characters _after_ you have typed a proceeding masked character. This change adds a directive modifier which can be used to set the `short` property on the masking `config` object.

Usage:
```
<input v-facade.short="(###) ###-#### x####" />
```