### PR TITLE
fix: firefox issue where masked value can overflow

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -4,13 +4,27 @@ const CONFIG_KEY = core.CONFIG_KEY
 export default {
   bind: (el, { value, modifiers }, vnode) => {
     el = core.getInputElement(el)
-    el.addEventListener('input', core.inputHandler, true)
-
     const config = core.normalizeConfig(value, modifiers)
     el[CONFIG_KEY] = { config }
 
     // set initial value
     core.updateValue(el, vnode, { force: config.prefill })
+  },
+
+  inserted: (el) => {
+    el = core.getInputElement(el)
+    const config = el[CONFIG_KEY]
+    // prefer adding event listener to parent element to avoid Firefox bug which does not
+    // execute `useCapture: true` event handlers before non-capturing event handlers
+    const handlerOwner = el.parentElement || el
+
+    // use anonymous event handler to avoid inadvertently removing masking for all inputs within a container
+    const handler = (e) => core.inputHandler(e)
+
+    handlerOwner.addEventListener('input', handler, true)
+
+    config.handler = handler
+    config.cleanup = () => handlerOwner.removeEventListener('input', config.handler, true)
   },
 
   update: (el, { value, oldValue, modifiers }, vnode) => {
@@ -24,5 +38,7 @@ export default {
     }
   },
 
-  unbind: (el) => el.removeEventListener('input', core.inputHandler, true)
+  unbind: (el) => {
+    core.getInputElement(el)[CONFIG_KEY].cleanup()
+  }
 }

--- a/src/directive.js
+++ b/src/directive.js
@@ -23,8 +23,7 @@ export default {
 
     handlerOwner.addEventListener('input', handler, true)
 
-    config.handler = handler
-    config.cleanup = () => handlerOwner.removeEventListener('input', config.handler, true)
+    config.cleanup = () => handlerOwner.removeEventListener('input', handler, true)
   },
 
   update: (el, { value, oldValue, modifiers }, vnode) => {

--- a/tests/directive.test.js
+++ b/tests/directive.test.js
@@ -15,7 +15,7 @@ describe('Directive', () => {
       directives: { facade },
       methods: { inputListener },
       data() {
-        return { mask }
+        return { mask, flag: true }
       }
     }
 
@@ -55,6 +55,29 @@ describe('Directive', () => {
     buildWrapper({ template, mask: '##.##' })
     expect(wrapper.find('#first').element.value).toBe('33.44')
     expect(wrapper.find('#second').element.value).toBe('3344')
+  })
+
+  test('Removing a masked input from the DOM should not impact other masked inputs in the same container', async () => {
+    const template = `<div id='owner'>
+        <input v-facade="mask" id="first" />
+        <input v-if="flag" v-facade="mask" id="second" />
+      </div>`
+
+    buildWrapper({ template, mask: '##.##' })
+
+    wrapper.find('#first').setValue('1111')
+    wrapper.find('#second').setValue('1111')
+
+    expect(wrapper.find('#first').element.value).toBe('11.11')
+    expect(wrapper.find('#second').element.value).toBe('11.11')
+
+    // remove #second input from DOM, triggering directive unbind
+    await wrapper.setData({ flag: false })
+    expect(wrapper.find('#second').exists()).toBeFalsy()
+
+    // ensure #first input is still being masked
+    wrapper.find('#first').setValue('1122')
+    expect(wrapper.find('#first').element.value).toBe('11.22')
   })
 
   test('Should update element value on input', async () => {


### PR DESCRIPTION
## Description
Firefox has a bug/inconsistency in their DOM event implementation which allows "bubbled" event listeners (`useCapture: false`) to be executed _before_ "captured" event handlers (`useCapture: true`) when the listeners are placed on the same event target. 

The effect of this inconsistency is that a standard vue event listener (`@input="handleInput"`) can execute _before_ the masking directive has a chance to process/capture the original input event, leading to potential inconsistencies where downstream event handlers receive a different value for the input than what is actually reflected by the DOM.

To avoid this problem, this change set updates the directive by adding the `input` event listener on the input element's parent, instead of the input element itself. Placing the listener on the parent ensures the correct execution order (capture listeners before bubble listeners).

Quote from [this issue comment ](https://github.com/RonaldJerez/vue-input-facade/issues/17#issuecomment-824354404)for more context and explanation:

> The vue-input-facade directive adds a _capturing_ event listener to the input, which theoretically helps ensure that the masking code executes _before_ normal vue event handlers (which do not specify `useCapture: true`). Chrome and Edge correctly execute the directive's `input` handler first, but Firefox does not.
> 
> Simple demonstration of the issue:
> 
> `Edge (chromium)`
> ![image](https://user-images.githubusercontent.com/4603206/115619693-34e96c00-a2c2-11eb-8f99-9511bf7212f7.png)
> 
> `Firefox`
> ![image](https://user-images.githubusercontent.com/4603206/115619760-4b8fc300-a2c2-11eb-9054-5e2d0253d265.png)
> 
> I haven't looked too much further into this yet, but I did make a quick change to the directive to add the `input` event handler on the input element's parent, and the issue in Firefox went away.
> 
> Basic explanation of capture/bubble event phases: https://www.quirksmode.org/js/events_order.html
> 
> Here is a codepen that can be used to quickly assess the capture/bubble: https://codepen.io/taylorcognito/pen/JjEeOGe?editors=1010

## Checklist
- [x] Tests
- [ ] Documentation
- [x] Used commitizen and followed [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Commit footer references issue num. If applicable.
