### PR TITLE
Allow typing static chars at beginning of value

### DIFF
--- a/docs/component.md
+++ b/docs/component.md
@@ -12,6 +12,18 @@ let masked = false
 <display :value="value" />
 ```
 
+```js
+let franceIBAN = 'FR7630006000011234567890189'
+let masked = true
+
+<example label="France IBAN">
+  <input-facade mask="FR## #### #### #### #### #### ###" v-model="franceIBAN" :masked="masked" />
+</example>
+
+<checkbox v-model="masked" />
+<display :value="franceIBAN" />
+```
+
 ### Dynamic Masks
 
 Accepts an array of masking pattern and dynamically chooses the appropriate one based on the number of characters in the field.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "test:watch": "jest --coverage --watchAll"
   },
   "main": "dist/vue-input-facade.umd.min.js",
-  "files": [ "dist/*.js" ],
+  "files": [
+    "dist/*.js"
+  ],
   "devDependencies": {
     "@vue/cli-plugin-babel": "^4.3.1",
     "@vue/cli-plugin-eslint": "^4.3.1",

--- a/src/masker.js
+++ b/src/masker.js
@@ -99,7 +99,7 @@ export function formatter(value, config) {
       valueIndex++
     } else {
       accumulator += maskChar
-      if (char === maskChar) {
+      if (char.toLocaleLowerCase() === maskChar.toLocaleLowerCase()) {
         // user typed the same char as static mask char
         valueIndex++
         if (!masker) {

--- a/src/masker.js
+++ b/src/masker.js
@@ -99,7 +99,7 @@ export function formatter(value, config) {
       valueIndex++
     } else {
       accumulator += maskChar
-      if (char.toLocaleLowerCase() === maskChar.toLocaleLowerCase()) {
+      if ((char && char.toLocaleLowerCase()) === (maskChar && maskChar.toLocaleLowerCase())) {
         // user typed the same char as static mask char
         valueIndex++
         if (!masker) {

--- a/src/masker.js
+++ b/src/masker.js
@@ -99,7 +99,15 @@ export function formatter(value, config) {
       valueIndex++
     } else {
       accumulator += maskChar
-      if (char === maskChar) valueIndex++ // user typed the same char
+      if (char === maskChar) {
+        // user typed the same char as static mask char
+        valueIndex++
+        if (!masker) {
+          // add it and reset
+          output.masked += accumulator
+          accumulator = ''
+        }
+      }
 
       escaped = false
       maskIndex++

--- a/src/masker.js
+++ b/src/masker.js
@@ -102,7 +102,7 @@ export function formatter(value, config) {
       if ((char && char.toLocaleLowerCase()) === (maskChar && maskChar.toLocaleLowerCase())) {
         // user typed the same char as static mask char
         valueIndex++
-        if (!masker) {
+        if (!masker || escaped) {
           // add it and reset
           output.masked += accumulator
           accumulator = ''

--- a/tests/formatter.test.js
+++ b/tests/formatter.test.js
@@ -46,7 +46,7 @@ test('123 -> ##(#)', () => {
   expect(formatter('123', { mask: '##(#)' })).toMatchObject({ masked: '12(3)', unmasked: '123' })
 })
 
-test('123 -> ##(#)', () => {
+test('12 -> ##(#)', () => {
   expect(formatter('12', { mask: '#\\#(#)' })).toMatchObject({ masked: '1#(2)', unmasked: '12' })
 })
 

--- a/tests/formatter.test.js
+++ b/tests/formatter.test.js
@@ -65,3 +65,13 @@ test('2 -> +1 # 5', () => {
 test('empty -> +1 # 5', () => {
   expect(formatter('', { mask: '+1 # 5', prefill: true })).toMatchObject({ masked: '+1 ', unmasked: '' })
 })
+
+test('France IBAN', () => {
+  expect(formatter('FR7630006000011234567890189', {
+    mask: 'FR## #### #### #### #### #### ###',
+    prefill: true
+  })).toMatchObject({
+    masked: 'FR76 3000 6000 0112 3456 7890 189',
+    unmasked: '7630006000011234567890189'
+  })
+})

--- a/tests/formatter.test.js
+++ b/tests/formatter.test.js
@@ -9,6 +9,11 @@ test('1 -> (#)', () => {
   expect(formatter('1', { mask: '(#)' })).toMatchObject({ masked: '(1)', unmasked: '1' })
 })
 
+test('(1) -> (#)', () => {
+  // static mask chars in source
+  expect(formatter('(1)', { mask: '(#)' })).toMatchObject({ masked: '(1)', unmasked: '1' })
+})
+
 test('1 -> [(#)]', () => {
   // two placeholder at the end
   expect(formatter('1', { mask: '[(#)]' })).toMatchObject({ masked: '[(1)]', unmasked: '1' })

--- a/tests/formatter.test.js
+++ b/tests/formatter.test.js
@@ -67,10 +67,12 @@ test('empty -> +1 # 5', () => {
 })
 
 test('France IBAN', () => {
-  expect(formatter('FR7630006000011234567890189', {
-    mask: 'FR## #### #### #### #### #### ###',
-    prefill: true
-  })).toMatchObject({
+  expect(
+    formatter('FR7630006000011234567890189', {
+      mask: 'FR## #### #### #### #### #### ###',
+      prefill: true
+    })
+  ).toMatchObject({
     masked: 'FR76 3000 6000 0112 3456 7890 189',
     unmasked: '7630006000011234567890189'
   })


### PR DESCRIPTION
## Description
Fix #34 by allowing source (typed) value to contain static mask chars at beginning

## Checklist
- [x] Tests
- [x] Documentation
- [x] Used commitizen and followed [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Commit footer references issue num. If applicable.
