### PR TITLE
fix(core.js): ignore composition text input events

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -57,7 +57,7 @@ export function inputHandler(event) {
   const { target, detail } = event
 
   // We dont need to run this method on the event we emit (prevent event loop)
-  if (detail && detail.facade) {
+  if ((detail && detail.facade) || event.inputType === 'insertCompositionText') {
     return false
   }
 


### PR DESCRIPTION
Ignore events triggered while composing text with an input method editor. Fixes up buggy behavior
with some IMEs resulting in incorrect cursor placement or duplicated inputs while updating the input
with a masked value.

## Description

While using some IMEs - e.g. Pinyin (Simplified), Japanese Hiragana  - updating the input value with a masked value while input text is being composed was causing text to be duplicated or for cursor positioning to be incorrectly updated. PR causes input events related to text composition to be ignored resulting in formatting and masking only being applied when the input composition is completed and text is inserted by the browser.

## Checklist
- [ ] Tests
- [ ] Documentation
- [x] Used commitizen and followed [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Commit footer references issue num. If applicable.
