### PR TITLE
feat(core.js): allow for turning on and off the masking

### DIFF
--- a/src/component.vue
+++ b/src/component.vue
@@ -98,7 +98,7 @@ export default {
       }
     },
     mask(newMask) {
-      if (!newMask) {
+      if (!newMask && !this.masked) {
         // when removing the masking rule, set the displayed value to the unmasked
         // to remove any unwanted masking characters from the input
         this.maskedValue = this.unmaskedValue
@@ -112,6 +112,7 @@ export default {
     config() {
       return {
         mask: this.mask,
+        masked: this.masked,
         tokens: this.tokens,
         formatter: this.formatter,
         prefill: this.prefill,

--- a/src/core.js
+++ b/src/core.js
@@ -91,7 +91,7 @@ export function updateCursor(event, originalValue, originalPosition) {
   // https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/setSelectionRange
   const supportedInputType = ['text', 'tel', 'search', null].includes(target.getAttribute('type'))
   const config = target[CONFIG_KEY] && target[CONFIG_KEY].config
-  if (target !== document.activeElement || !supportedInputType || !config.mask) {
+  if (target !== document.activeElement || !supportedInputType || (!config.mask && !config.masked)) {
     return
   }
 


### PR DESCRIPTION
### Description
Add a prop to use the maskedValue even when the mask is an empty string and maintains the cursor position

#### Coverage
```bash
---------------|----------|----------|----------|----------|-------------------|
File           |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
---------------|----------|----------|----------|----------|-------------------|
All files      |    99.38 |    94.66 |    96.88 |      100 |                   |
 component.vue |      100 |    91.67 |      100 |      100 |               103 |
 core.js       |      100 |    96.97 |     87.5 |      100 |           112,142 |
 directive.js  |      100 |      100 |      100 |      100 |                   |
 masker.js     |    98.39 |    91.49 |      100 |      100 |         12,63,105 |
 tokens.js     |      100 |      100 |      100 |      100 |                   |
---------------|----------|----------|----------|----------|-------------------|

Test Suites: 5 passed, 5 total
Tests:       62 passed, 62 total
Snapshots:   0 total
Time:        2.545s, estimated 3s
```