### PR TITLE
fix: handle composition events for better international keyboard support

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -26,9 +26,30 @@ export default {
       core.inputHandler(e, el)
     }
 
-    handlerOwner.addEventListener('input', handler, true)
+    const compositionHandler = (e) => {
+      if (e.target !== el) {
+        return
+      }
 
-    config.cleanup = () => handlerOwner.removeEventListener('input', handler, true)
+      if (['compositionstart', 'compositionupdate'].includes(e.type)) {
+        el[CONFIG_KEY].isComposing = true
+      } else if (e.type === 'compositionend') {
+        el[CONFIG_KEY].isComposing = false
+        core.inputHandler(e, el)
+      }
+    }
+
+    handlerOwner.addEventListener('input', handler, true)
+    handlerOwner.addEventListener('compositionstart', compositionHandler, true)
+    handlerOwner.addEventListener('compositionupdate', compositionHandler, true)
+    handlerOwner.addEventListener('compositionend', compositionHandler, true)
+
+    config.cleanup = () => {
+      handlerOwner.removeEventListener('input', handler, true)
+      handlerOwner.removeEventListener('compositionstart', compositionHandler, true)
+      handlerOwner.removeEventListener('compositionend', compositionHandler, true)
+      handlerOwner.removeEventListener('compositionupdate', compositionHandler, true)
+    }
   },
 
   update: (el, { value, oldValue, modifiers }, vnode) => {


### PR DESCRIPTION
## Description

Add handling for composition events, allowing users to compose inputs normally before committing a
value to be masked. Supplements the fix from v1.3.8 with more robust handling of the composition events.

Input methods that use input composition will allow users to compose input before it is inserted and the mask is applied to the input value. The input's v-model will not be updated until the text is inserted and the mask applied. This prevents input values that are actively being composed from being propagated from the masked input.

### Example Screen Videos

Using a Chinese Pinyin keyboard on Windows, numeric inputs are handled correctly when masked:

![input-facade-chinese-input-numeric](https://user-images.githubusercontent.com/682843/151881092-7d9e3939-e9b2-4551-8b45-bbdd0e088a96.gif)

Using a Chinese Pinyin keyboard on Windows, users can compose text before a mask is applied. v-model value does not update until text is inserted and masked:

![input-facade-chinese-input-alphanumeric](https://user-images.githubusercontent.com/682843/151881258-335c239b-eb83-4669-8a7d-8775df9a8c5e.gif)

Using a Chinese Pinyin keyboard on MacOS in Safari (Safari has an additional Input event for when composition text is inserted), input can be composed before the mask is applied. v-model value does not update until text is inserted after composing:

![input-facade-chinese-input-safari-alphanum](https://user-images.githubusercontent.com/682843/151881496-d1348cb0-c0a7-4e06-b1fc-58ac2743a11f.gif)

Using a Japanese keyboard, full-width numbers trigger composition, half-width numbers can be selected and inserted:

![input-facade-japanese-input-numeric](https://user-images.githubusercontent.com/682843/151881930-8aa1f572-3069-48ac-a7c7-287645df6ee4.gif)

## Checklist
- [X] Tests
- [ ] Documentation
- [X] Used commitizen and followed [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Commit footer references issue num. If applicable.

