### PR TITLE
fix(masker.js): first character escaped

### DIFF
--- a/src/masker.js
+++ b/src/masker.js
@@ -77,16 +77,17 @@ export function formatter(value, config) {
     const masker = tokens[maskChar]
     let char = value[valueIndex]
 
+    // when is escape char, do not mask, just continue
+    if (masker && masker.escape) {
+      escaped = true
+      maskIndex++
+      continue
+    }
+
     // no more input characters and next character is a masked one
-    if (!char && masker) break
+    if (!char && masker && !escaped) break
 
     if (masker && !escaped) {
-      // when is escape char, do not mask, just continue
-      if (masker.escape) {
-        escaped = true
-        maskIndex++
-        continue
-      }
 
       if (masker.pattern.test(char)) {
         char = masker.transform ? masker.transform(char) : char

--- a/src/masker.js
+++ b/src/masker.js
@@ -77,17 +77,16 @@ export function formatter(value, config) {
     const masker = tokens[maskChar]
     let char = value[valueIndex]
 
-    // when is escape char, do not mask, just continue
-    if (masker && masker.escape) {
-      escaped = true
-      maskIndex++
-      continue
-    }
-
-    // no more input characters and next character is a masked one
-    if (!char && masker && !escaped) break
-
     if (masker && !escaped) {
+      // when is escape char, do not mask, just continue
+      if (masker.escape) {
+        escaped = true
+        maskIndex++
+        continue
+      }
+
+      // no more input characters and next character is a masked one
+      if (!char) break
 
       if (masker.pattern.test(char)) {
         char = masker.transform ? masker.transform(char) : char

--- a/tests/formatter.test.js
+++ b/tests/formatter.test.js
@@ -66,6 +66,14 @@ test('empty -> +1 # 5', () => {
   expect(formatter('', { mask: '+1 # 5', prefill: true })).toMatchObject({ masked: '+1 ', unmasked: '' })
 })
 
+test('escaped -> \\+1 # 5', () => {
+  expect(formatter('', { mask: '\\+1 # 5', prefill: true })).toMatchObject({ masked: '+1 ', unmasked: '' })
+})
+
+test('2 -> \\A # 5 \\A\\A', () => {
+  expect(formatter('2', { mask: '\\A # 5 \\A\\A', prefill: true })).toMatchObject({ masked: 'A 2 5 AA', unmasked: '2' })
+})
+
 test('France IBAN', () => {
   expect(
     formatter('FR7630006000011234567890189', {


### PR DESCRIPTION
Fix first escaped character with prefill

Before fix:
`\\A # 5` -> ` `

After fix:
`\\A # 5` -> `A `
