### PR TITLE
feat: add support for repeating characters one or more

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ export default {
 + `\` = escape any of the above characters
 + `?` = mark the preceding character as optional [0 or 1]
 + `*` = mark the preceding character as optional & repeating [0 or more]
++ `+` = mark the preceding character as repeating [1 or more]
 
 See the [token source file](https://github.com/RonaldJerez/vue-input-facade/blob/master/src/tokens.js) for definition signature
 

--- a/src/masker.js
+++ b/src/masker.js
@@ -71,6 +71,7 @@ export function formatter(value, config) {
 
   let valueIndex = 0
   let maskIndex = 0
+  let testIndex = 0
   let accumulator = ''
 
   // gets some information about the mask before formating
@@ -81,7 +82,8 @@ export function formatter(value, config) {
     return {
       escape: !!(masker && masker.escape),
       optional: !!(nextMasker && nextMasker.optional),
-      repeat: !!(nextMasker && nextMasker.repeat)
+      repeatZero: !!(nextMasker && nextMasker.repeatZero),
+      repeatOne: !!(nextMasker && nextMasker.repeatOne)
     }
   }
 
@@ -110,10 +112,15 @@ export function formatter(value, config) {
 
         accumulator = ''
 
-        if (!meta.repeat) {
+        if (!meta.repeatZero && !meta.repeatOne) {
           maskIndex += meta.optional ? 2 : 1
+        } else if (meta.repeatOne) {
+          testIndex++
         }
-      } else if (meta.optional || meta.repeat) {
+      } else if (meta.optional || meta.repeatZero) {
+        maskIndex += 2
+        continue
+      } else if (meta.repeatOne && testIndex > 0) {
         maskIndex += 2
         continue
       }
@@ -133,6 +140,7 @@ export function formatter(value, config) {
 
       escaped = false
       maskIndex++
+      testIndex = 0
     }
   }
 

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -6,5 +6,6 @@ export default {
   a: { pattern: /[a-z]/i, transform: (v) => v.toLocaleLowerCase() },
   '\\': { escape: true },
   '?': { optional: true },
-  '*': { repeat: true }
+  '*': { repeatZero: true },
+  '+': { repeatOne: true }
 }

--- a/tests/directive.test.js
+++ b/tests/directive.test.js
@@ -190,7 +190,7 @@ describe('Directive', () => {
     })
 
     test('Should honor prefill modifier', async () => {
-      buildWrapper({ modifiers: 'prefill', mask: '+1 ###', value: '' })
+      buildWrapper({ modifiers: 'prefill', mask: '\\+1 ###', value: '' })
       expect(wrapper.element.value).toBe('+1 ')
 
       wrapper.element.value = '777'

--- a/tests/formatter.test.js
+++ b/tests/formatter.test.js
@@ -51,19 +51,19 @@ test('12 -> ##(#)', () => {
 })
 
 test('12 -> +1 #', () => {
-  expect(formatter('12', { mask: '+1 #' })).toMatchObject({ masked: '+1 2', unmasked: '2' })
+  expect(formatter('12', { mask: '\\+1 #' })).toMatchObject({ masked: '+1 2', unmasked: '2' })
 })
 
 test('2 -> +1 #', () => {
-  expect(formatter('2', { mask: '+1 #' })).toMatchObject({ masked: '+1 2', unmasked: '2' })
+  expect(formatter('2', { mask: '\\+1 #' })).toMatchObject({ masked: '+1 2', unmasked: '2' })
 })
 
 test('2 -> +1 # 5', () => {
-  expect(formatter('2', { mask: '+1 # 5' })).toMatchObject({ masked: '+1 2 5', unmasked: '2' })
+  expect(formatter('2', { mask: '\\+1 # 5' })).toMatchObject({ masked: '+1 2 5', unmasked: '2' })
 })
 
 test('empty -> +1 # 5', () => {
-  expect(formatter('', { mask: '+1 # 5', prefill: true })).toMatchObject({ masked: '+1 ', unmasked: '' })
+  expect(formatter('', { mask: '\\+1 # 5', prefill: true })).toMatchObject({ masked: '+1 ', unmasked: '' })
 })
 
 test('12.345 -> ##?#?.###', () => {
@@ -128,11 +128,45 @@ test('abc1234xyz -> ##* AAA', () => {
 })
 
 test('escaped -> \\+1 # 5', () => {
-  expect(formatter('', { mask: '\\+1 # 5', prefill: true })).toMatchObject({ masked: '+1 ', unmasked: '' })
+  expect(formatter('', { mask: '\\+1 # 5', prefill: true })).toMatchObject({
+    masked: '+1 ',
+    unmasked: ''
+  })
 })
 
 test('2 -> \\A # 5 \\A\\A', () => {
-  expect(formatter('2', { mask: '\\A # 5 \\A\\A', prefill: true })).toMatchObject({ masked: 'A 2 5 AA', unmasked: '2' })
+  expect(formatter('2', { mask: '\\A # 5 \\A\\A', prefill: true })).toMatchObject({
+    masked: 'A 2 5 AA',
+    unmasked: '2'
+  })
+})
+
+test('123456 -> #+', () => {
+  expect(formatter('123456', { mask: '#+' })).toMatchObject({
+    masked: '123456',
+    unmasked: '123456'
+  })
+})
+
+test('1234HH -> #+ AA', () => {
+  expect(formatter('1234HH', { mask: '#+ AA' })).toMatchObject({
+    masked: '1234 HH',
+    unmasked: '1234HH'
+  })
+})
+
+test('abc1234xyz -> ##+ AAA', () => {
+  expect(formatter('abc1234xyz', { mask: '##+ AAA' })).toMatchObject({
+    masked: '1234 XYZ',
+    unmasked: '1234XYZ'
+  })
+})
+
+test('abc1234xyz -> a+##+ AAA', () => {
+  expect(formatter('abc1234xyz', { mask: 'a+##+ AAA' })).toMatchObject({
+    masked: 'abc1234 XYZ',
+    unmasked: 'abc1234XYZ'
+  })
 })
 
 test('France IBAN', () => {


### PR DESCRIPTION
Add support for repeating characters one or more

Example:

`#+A+` -> `123AAAA`