### PR TITLE
fix(core.js): allow native handling of composition events when no mas…

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -148,7 +148,7 @@ export function updateValue(el, vnode, { emit = true, force = false } = {}, even
   let currentValue = vnode?.data?.model?.value || el.value
 
   // manipulating input value while text is being composed can lead to inputs being duplicated
-  if (isComposing) {
+  if (config.mask && isComposing) {
     return
   }
 


### PR DESCRIPTION
## Description
Allow native handling of composition events when no mask is passed.

In [v1.3.9](https://github.com/RonaldJerez/vue-input-facade/releases/tag/v1.3.9) we added composition event handing to address a bug with in time masking on certain IMEs. We would like to keep these changes only when passed a mask and continue to emit events when there is no mask.

## Checklist
- [x] Tests
- [x] Documentation
- [x] Used commitizen and followed [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Commit footer references issue num. If applicable.
