### PR TITLE
fix(filter): remove unsupported Vue.filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ yarn add vue-input-facade@beta
 
 ### Globally
 
-Installs the component, directive and filter for your entire application.
+Installs the component and directive for your entire application.
 
 ```javascript
 import InputFacade from 'vue-input-facade'
@@ -45,12 +45,14 @@ app.use(InputFacade)
 Install per component as needed
 
 ```javascript
-import { InputFacade, facade, filter } from 'vue-input-facade'
+import { InputFacade, facade, masker } from 'vue-input-facade'
 
 export default {
   components: { InputFacade },
   directives: { facade },
-  filters: { facade: filter },
+  setup() {
+    return { masker }
+  }
   // ... rest of component config
 }
 ```

--- a/docs/filter.md
+++ b/docs/filter.md
@@ -1,8 +1,0 @@
-You may use the library to mask values in static text as well, taking advantage of the same mask tokens.
-
-```js 
-let phoneNumber = 18001234567
-let orderNumber = 'ABC1234510'
-
-<p>Thanks for ordering with us. Your order number is <b>{{ orderNumber | facade('SSS-#####-##') }}</b>.  If you need assitance please call us at <b>{{ phoneNumber | facade('#-###-###-####') }}</b></p>
-```

--- a/docs/masker.md
+++ b/docs/masker.md
@@ -1,0 +1,8 @@
+You may use the library to mask values in static text as well, taking advantage of the same mask tokens.
+
+```js 
+let phoneNumber = 18001234567
+let orderNumber = 'ABC1234510'
+
+<p>Thanks for ordering with us. Your order number is <b>{{ masker(orderNumber, 'SSS-#####-##').masked }}</b>.  If you need assistance please call us at <b>{{ facade(phoneNumber, '#-###-###-####').masked }}</b></p>
+```

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "build:docs": "vue-cli-service styleguidist:build --config styleguide/config.js",
     "test": "jest --coverage",
     "test:filter": "func() { yarn test \"$1\" --coverage-reporters=\"lcov\" --coverageThreshold={} ${@:2}; }; func",
-    "test:watch": "jest --coverage --watchAll"
+    "test:watch": "jest --coverage --watchAll",
+    "preyalcpublish": "yarn build:plugin"
   },
   "main": "dist/vue-input-facade.umd.min.js",
   "files": [

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -18,22 +18,10 @@ function install(Vue, options = {}) {
 
   Vue.component(InputFacade.name, InputFacade)
   Vue.directive(options.name || 'facade', facade)
-  Vue.filter(options.name || 'facade', filter)
-}
-
-/**
- * Utility function to be used as a vue filter
- *
- * @param {String} value the value to apply the filter to
- * @param {*} config the masking config
- * @returns {string} the masked value as returned by the masker function
- */
-function filter(value, config) {
-  return masker(value, config).masked
 }
 
 export default install
-export { InputFacade, facade, tokens, masker, filter }
+export { InputFacade, facade, tokens, masker }
 
 // Install by default if included from script tag
 if (typeof window !== 'undefined' && window.Vue) {

--- a/styleguide/config.js
+++ b/styleguide/config.js
@@ -1,6 +1,6 @@
 const path = require('path')
 const pkg = require('../package.json')
-const { execSync } = require('child_process');
+const { execSync } = require('child_process')
 
 const root = path.resolve(__dirname, '../')
 
@@ -35,8 +35,8 @@ module.exports = {
       content: `${root}/docs/directive.md`
     },
     {
-      name: 'Filter',
-      content: `${root}/docs/filter.md`
+      name: 'Masker',
+      content: `${root}/docs/masker.md`
     },
     {
       name: 'Advanced',


### PR DESCRIPTION
## Description
Vue 3 upgrade gives errors due to the deprecated `Vue.filter`. This PR fixes this issue by removing the filter altogether. As mentioned by Ronald [further down](https://github.com/RonaldJerez/vue-input-facade/pull/81#discussion_r1261291182) we can use the already exported `masker` directly instead.

For example:
```vue
<template>
  <div> {{ masker('1234', '###-#').masked }} </div>
</template>

<script>
import { masker } from 'vue-input-facade'

export default {
  setup() {
    return { masker }
  }
}

</script>
```

**Note**: Not marking this as a breaking change as the existing beta branch was already broken for Vue 3.

## Checklist
- [x] Tests
- [x] Documentation
- [x] Used commitizen and followed [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Commit footer references issue num. If applicable.
